### PR TITLE
feat: polish home screen — arch removal, unified hero card, warmup bottom sheet, preset data limits

### DIFF
--- a/.claude/PRPs/plans/completed/home-screen-design-enhancements.plan.md
+++ b/.claude/PRPs/plans/completed/home-screen-design-enhancements.plan.md
@@ -1,0 +1,721 @@
+# Plan: Home Screen Design Enhancements
+
+## Summary
+Refine the home dashboard to be cleaner and more data-driven across 5 targeted changes: remove the arch banner decoration, unify the two session hero cards into one real-data card with the gradient design, move warmup category selection into a bottom-sheet modal triggered by the Start button, cap the Programs and Sessions carousels to preset-only data (5 programs, 10 sessions), and remove the sign-out button.
+
+## User Story
+As a user, I want a cleaner home screen that shows real workout data in the hero cards and doesn't overwhelm me with too many items, so that the home screen feels polished and focused.
+
+## Problem → Solution
+- Arch clipper creates a heavy, dated bottom curve → flat/subtle bottom edge (no clip)
+- Two side-by-side session cards (hardcoded hero + real program day) → single gradient hero card showing real active program data
+- Warmup category button in home screen clutters layout and requires full navigation → category selection as bottom sheet on Start tap
+- Programs carousel shows ALL programs (preset + user), Sessions carousel shows hardcoded data → Programs limited to 5 presets, Sessions from `presetSessionsProvider` limited to 10
+- Sign-out button in home body → removed (to be placed elsewhere)
+
+## Metadata
+- **Complexity**: Medium
+- **Source PRD**: N/A
+- **PRD Phase**: N/A
+- **Estimated Files**: 2 (home_dashboard_tab.dart, workout_providers.dart)
+
+---
+
+## UX Design
+
+### Before
+```
+┌──────────────────────────────────────────┐
+│  ╔══════════════════════════════════╗    │
+│  ║  Good morning, Name             ║    │
+│  ║  [streak] [week] [trophies]     ║    │
+│  ╚══════════╗ arch curve ╔══════════╝   │
+│             ╚════════════╝              │
+│  [SESSION OF THE DAY - hardcoded]       │
+│  [CURRENT PROGRAM DAY - real data]      │
+│  [DAILY CHALLENGE]                      │
+│  Warmup: [🔧 Category chip] [2][5][10]  │
+│          [▶ Start warmup]               │
+│  Programs: [card][card][card]...all     │
+│  Sessions: [card][card][card]...hc      │
+│  [Sign out button]                      │
+└──────────────────────────────────────────┘
+```
+
+### After
+```
+┌──────────────────────────────────────────┐
+│  ╔══════════════════════════════════╗    │
+│  ║  Good morning, Name             ║    │
+│  ║  [streak] [week] [trophies]     ║    │
+│  ╚══════════════════════════════════╝    │
+│        (no arch — flat/subtle bottom)   │
+│  [SESSION HERO CARD - gradient + real]  │
+│    (shows active program session data)  │
+│  [DAILY CHALLENGE]                      │
+│  Warmup: [2 min][5 min][10 min]         │
+│          [▶ Start warmup]               │
+│   ← tapping Start opens bottom sheet:  │
+│     ┌─ Choose focus area ─────────┐    │
+│     │ [Full Body] [Upper Body]... │    │
+│     │ [Confirm ▶] (disabled until │    │
+│     │  selection made)            │    │
+│     └─────────────────────────────┘    │
+│  Programs: [card][card]...(max 5)       │
+│  Sessions: [card][card]...(max 10 real) │
+│  (no sign-out button)                   │
+└──────────────────────────────────────────┘
+```
+
+### Interaction Changes
+| Touchpoint | Before | After | Notes |
+|---|---|---|---|
+| Banner bottom edge | Arch clipper curve | Flat bottom, no ClipPath | Remove `_ArchClipper` and `ClipPath` wrapper |
+| Session hero card | Hardcoded "Full Body Power" gradient card | Gradient card with real active program session data | Merge `_SessionOfTheDayCard` + `_CurrentProgramDayCard` |
+| Current program day card | Separate simpler bordered card | Removed; merged into hero card | Delete `_CurrentProgramDayCard` |
+| Warmup category chip | Tapping opens `WarmupCategoryScreen` as new route | Removed; category selected in bottom sheet | Remove category chip from `_WarmupSelector` |
+| Start warmup button | Immediately starts warmup with current category | Opens category selection bottom sheet first | Bottom sheet has disabled Confirm until selection |
+| Programs carousel | All programs (preset + user), unlimited | Preset only, max 5 | New `homePresetProgramsProvider` |
+| Sessions carousel | Hardcoded `_SessionData` list | Real `presetSessionsProvider` data, max 10 | Convert `_SessionsCarousel` to `ConsumerWidget` |
+| Sign-out button | `_LogoutButton` at bottom of home | Removed entirely | Delete `_LogoutButton` class and usage |
+
+---
+
+## Mandatory Reading
+
+| Priority | File | Lines | Why |
+|---|---|---|---|
+| P0 (critical) | `lib/views/home/home_dashboard_tab.dart` | 208-273 | `_HomeBannerSliver` + `_ArchClipper` to modify |
+| P0 (critical) | `lib/views/home/home_dashboard_tab.dart` | 503-707 | `_SessionOfTheDayCard` design to reuse |
+| P0 (critical) | `lib/views/home/home_dashboard_tab.dart` | 884-1141 | `_CurrentProgramDayCard` + `_ProgramCardContainer` to remove/merge |
+| P0 (critical) | `lib/views/home/home_dashboard_tab.dart` | 1143-1343 | `_WarmupSelector` — category chip + Start button |
+| P0 (critical) | `lib/views/home/home_dashboard_tab.dart` | 1345-1565 | `_ProgramsCarousel` + `_ProgramCard` |
+| P0 (critical) | `lib/views/home/home_dashboard_tab.dart` | 1567-1783 | `_SessionsCarousel` + `_SessionCard` + `_SessionData` |
+| P0 (critical) | `lib/views/home/home_dashboard_tab.dart` | 1882-1909 | `_LogoutButton` to delete |
+| P1 (important) | `lib/providers/workout_providers.dart` | 95-103 | `presetSessionsProvider` — source for sessions carousel |
+| P1 (important) | `lib/providers/workout_providers.dart` | 226-237 | `programsProvider` — source for programs carousel |
+| P1 (important) | `lib/features/warmup/presentation/screens/warmup_category_screen.dart` | 1-137 | Category cards to reuse in bottom sheet |
+| P2 (reference) | `lib/core/theme/app_dimensions.dart` | all | `AppSpacing`, `AppRadii` constants |
+| P2 (reference) | `lib/core/theme/colors.dart` | all | `AppColors` constants |
+| P2 (reference) | `lib/core/theme/app_opacity.dart` | all | `AppOpacity` constants |
+
+## External Documentation
+| Topic | Source | Key Takeaway |
+|---|---|---|
+| N/A | N/A | Feature uses established internal patterns only |
+
+---
+
+## Patterns to Mirror
+
+### NAMING_CONVENTION
+```dart
+// SOURCE: lib/views/home/home_dashboard_tab.dart:503
+class _SessionOfTheDayCard extends StatelessWidget { ... }
+// Private classes start with _ for file-private widgets
+// ConsumerWidget when using ref.watch, ConsumerStatefulWidget when needing state
+```
+
+### CARD_GRADIENT_DESIGN
+```dart
+// SOURCE: lib/views/home/home_dashboard_tab.dart:510-666
+Container(
+  decoration: BoxDecoration(
+    borderRadius: BorderRadius.circular(AppRadii.sm),
+    gradient: const LinearGradient(
+      begin: Alignment.topLeft,
+      end: Alignment.bottomRight,
+      colors: <Color>[AppColors.primaryDark, AppColors.primary, AppColors.cornflowerBlue],
+      stops: <double>[0.0, 0.45, 1.0],
+    ),
+    boxShadow: <BoxShadow>[
+      BoxShadow(
+        color: AppColors.primary.withValues(alpha: AppOpacity.moderate),
+        blurRadius: 24,
+        offset: const Offset(0, 10),
+      ),
+    ],
+  ),
+  child: ClipRRect(
+    borderRadius: BorderRadius.circular(AppRadii.sm),
+    child: Stack(
+      children: <Widget>[
+        // Decorative ring top-right: Positioned(right: -36, top: -36, ...)
+        // Decorative ring bottom-left: Positioned(left: -20, bottom: -44, ...)
+        // Content: Padding(padding: EdgeInsets.all(AppSpacing.lg), child: Column(...))
+      ],
+    ),
+  ),
+)
+```
+
+### SESSION_META_CHIP
+```dart
+// SOURCE: lib/views/home/home_dashboard_tab.dart:671-707
+class _SessionMetaChip extends StatelessWidget {
+  // Container with white semi-transparent bg, row of Icon + Text
+  // Used for: timer, exercise count, difficulty level
+}
+```
+
+### CONSUMER_WIDGET_PATTERN
+```dart
+// SOURCE: lib/views/home/home_dashboard_tab.dart:884-887
+class _CurrentProgramDayCard extends ConsumerWidget {
+  final bool isFrench;
+  const _CurrentProgramDayCard({required this.isFrench});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final someAsync = ref.watch(someProvider);
+    return someAsync.when(
+      data: (data) { ... },
+      loading: () => ...,
+      error: (_, __) => ...,
+    );
+  }
+}
+```
+
+### BOTTOM_SHEET_PATTERN
+```dart
+// Standard Flutter bottom sheet pattern used in this codebase:
+showModalBottomSheet<void>(
+  context: context,
+  isScrollControlled: true,
+  backgroundColor: AppColors.background,
+  shape: const RoundedRectangleBorder(
+    borderRadius: BorderRadius.vertical(top: Radius.circular(AppRadii.lg)),
+  ),
+  builder: (context) => StatefulBuilder(
+    builder: (context, setState) { ... }
+  ),
+);
+```
+
+### PROVIDER_FAMILY_PATTERN
+```dart
+// SOURCE: lib/providers/workout_providers.dart:96-103
+final presetSessionsProvider = FutureProvider<List<Session>>((ref) async {
+  final syncService = ref.watch(syncServiceProvider);
+  try {
+    return await syncService.getPresetSessions();
+  } catch (_) {
+    return [];
+  }
+});
+```
+
+### ASYNC_WHEN_PATTERN
+```dart
+// SOURCE: lib/views/home/home_dashboard_tab.dart:1373-1430
+return programsAsync.when(
+  data: (programs) {
+    if (programs.isEmpty) { return Center(child: Text(...)); }
+    return ListView.separated( ... );
+  },
+  loading: () => ListView.separated( /* skeleton */ ),
+  error: (_, __) => Center(child: Text(...)),
+);
+```
+
+---
+
+## Files to Change
+
+| File | Action | Justification |
+|---|---|---|
+| `lib/views/home/home_dashboard_tab.dart` | UPDATE | All 5 UI changes |
+| `lib/providers/workout_providers.dart` | UPDATE | Add `homePresetProgramsProvider` (max 5) |
+
+## NOT Building
+
+- Warmup category screen (`warmup_category_screen.dart`) stays as-is (still used elsewhere if needed)
+- Navigation or routing changes to other tabs
+- Profile/settings screen for sign-out (sign-out button is removed, future placement is out of scope)
+- Sessions carousel "See all" navigation (currently a no-op, leave as-is)
+- Programs carousel "See all" navigation (currently a no-op, leave as-is)
+- Any change to `_DailyChallengeCard`, `_QuickAccessRow`, or other sections
+- Warmup duration buttons (keep as-is)
+
+---
+
+## Step-by-Step Tasks
+
+### Task 1: Remove Arch — Flatten the banner bottom edge
+- **ACTION**: Remove `ClipPath` + `_ArchClipper` from `_HomeBannerSliver`, delete `_ArchClipper` class
+- **IMPLEMENT**:
+  In `_HomeBannerSliver.build`, replace:
+  ```dart
+  return SliverToBoxAdapter(
+    child: ClipPath(
+      clipper: _ArchClipper(),
+      child: AppTopBarBackground(
+        child: Padding( ... )
+      ),
+    ),
+  );
+  ```
+  With:
+  ```dart
+  return SliverToBoxAdapter(
+    child: AppTopBarBackground(
+      child: Padding(
+        padding: EdgeInsets.fromLTRB(
+          AppSpacing.lg,
+          topPadding + AppSpacing.md,
+          AppSpacing.lg,
+          AppSpacing.lg,  // reduced bottom padding (no arch offset needed)
+        ),
+        child: Column( ... ),
+      ),
+    ),
+  );
+  ```
+  Then delete the entire `_ArchClipper` class (lines 388-406).
+- **MIRROR**: NAMING_CONVENTION
+- **IMPORTS**: None new
+- **GOTCHA**: Bottom padding was `AppSpacing.lg + AppSpacing.md` to compensate for the arch offset. Reduce to just `AppSpacing.lg` since arch is gone.
+- **VALIDATE**: Hot reload; banner should have a clean flat bottom edge, no arch curve.
+
+### Task 2: Merge session hero cards — real data with gradient design
+- **ACTION**: Replace `_SessionOfTheDayCard` (hardcoded) and `_CurrentProgramDayCard` (real data) with a single `_SessionHeroCard` that uses the gradient design of the old `_SessionOfTheDayCard` but reads from `activeProgramStateProvider` and `programByIdProvider`
+- **IMPLEMENT**:
+  1. In `_HomeDashboardTabState.build`, replace:
+     ```dart
+     // Session of the Day
+     _SessionOfTheDayCard(isFrench: isFrench),
+     const SizedBox(height: AppSpacing.md),
+     // Active Program Day
+     _CurrentProgramDayCard(isFrench: isFrench),
+     ```
+     With:
+     ```dart
+     _SessionHeroCard(isFrench: isFrench),
+     ```
+  2. Create `_SessionHeroCard extends ConsumerWidget`:
+     - Watches `activeProgramStateProvider`
+     - If active program: also watches `programByIdProvider(activeProgramState.programId)`
+     - **No active program state**: render gradient card with "SESSION OF THE DAY" label, placeholder title "Ready to train?", subtitle prompt to start a program, play button
+     - **Has active program + loaded**: render gradient card with:
+       - Label: isFrench ? 'SÉANCE DU JOUR' : 'SESSION OF THE DAY'
+       - Title: the program name
+       - Subtitle: `Week $currentWeek / Day $currentDay` info
+       - Meta chips: duration chip (show `estimatedDuration` if available), exercises count, difficulty
+       - Tapping navigates to `ProgramDetailScreen.route(program: program)`
+     - **Loading state**: show gradient card with a white `CircularProgressIndicator` centered
+     - Design: EXACTLY the same as `_SessionOfTheDayCard` — same gradient, same decorative rings, same `_SessionMetaChip` chips
+     - Compute `currentDay`, `currentWeek`, `progress` using same arithmetic as old `_CurrentProgramDayCard` (lines 949-963)
+  3. Delete `_SessionOfTheDayCard` class and `_CurrentProgramDayCard` class and `_ProgramCardContainer` class
+- **MIRROR**: CARD_GRADIENT_DESIGN, CONSUMER_WIDGET_PATTERN, SESSION_META_CHIP, ASYNC_WHEN_PATTERN
+- **IMPORTS**: Need `ProgramDetailScreen` (already imported), `activeProgramStateProvider`, `programByIdProvider` (already imported via `workout_providers.dart`)
+- **GOTCHA**: The old `_ProgramCardContainer` is only used by `_CurrentProgramDayCard`. Delete it too. The `progress` field was used for a `LinearProgressIndicator` — can optionally add that as a subtle strip at the bottom of the gradient card or omit it for simplicity. Keep it omitted for the first pass (cleaner card).
+- **VALIDATE**: Hot reload; see a single gradient card. If user has an active program, it shows program name + day info. If no active program, shows placeholder. Tapping navigates to program detail.
+
+### Task 3: Warmup — category selection via bottom sheet on Start tap
+- **ACTION**: Remove the category chip from `_WarmupSelector`, convert Start button to open a category-selection bottom sheet before launching the workout
+- **IMPLEMENT**:
+  1. Remove the category chip `GestureDetector` block (lines 1178-1213) and the `SizedBox(height: AppSpacing.sm)` after it from `_WarmupSelectorState.build`
+  2. Replace the `FilledButton.icon` `onPressed` handler:
+     ```dart
+     onPressed: () {
+       _showCategorySheet(context);
+     },
+     ```
+  3. Add method `_showCategorySheet` to `_WarmupSelectorState`:
+     ```dart
+     void _showCategorySheet(BuildContext context) {
+       WarmupCategory? selected = ref.read(warmupCategoryProvider);
+       showModalBottomSheet<void>(
+         context: context,
+         isScrollControlled: true,
+         backgroundColor: AppColors.surface,
+         shape: const RoundedRectangleBorder(
+           borderRadius: BorderRadius.vertical(top: Radius.circular(AppRadii.lg)),
+         ),
+         builder: (sheetContext) => StatefulBuilder(
+           builder: (sheetContext, setSheetState) {
+             return Padding(
+               padding: const EdgeInsets.fromLTRB(
+                 AppSpacing.md, AppSpacing.md, AppSpacing.md, AppSpacing.lg),
+               child: Column(
+                 mainAxisSize: MainAxisSize.min,
+                 crossAxisAlignment: CrossAxisAlignment.start,
+                 children: [
+                   // Handle
+                   Center(
+                     child: Container(
+                       width: 40, height: 4,
+                       decoration: BoxDecoration(
+                         color: AppColors.primaryLight.withValues(alpha: AppOpacity.moderate),
+                         borderRadius: BorderRadius.circular(2),
+                       ),
+                     ),
+                   ),
+                   const SizedBox(height: AppSpacing.md),
+                   Text(
+                     widget.isFrench ? 'Zone d\'échauffement' : 'Choose focus area',
+                     style: const TextStyle(
+                       color: AppColors.textPrimary,
+                       fontSize: 18, fontWeight: FontWeight.w700,
+                       fontFamily: 'AppFontMedium',
+                     ),
+                   ),
+                   const SizedBox(height: AppSpacing.sm),
+                   // Category list (reuse _categoryLabels)
+                   for (final entry in _categoryLabels.entries)
+                     _WarmupCategoryTile(
+                       category: entry.key,
+                       label: widget.isFrench ? entry.value.$2 : entry.value.$1,
+                       isSelected: selected == entry.key,
+                       onTap: () => setSheetState(() => selected = entry.key),
+                     ),
+                   const SizedBox(height: AppSpacing.md),
+                   SizedBox(
+                     width: double.infinity,
+                     child: FilledButton.icon(
+                       onPressed: selected == null ? null : () {
+                         ref.read(warmupCategoryProvider.notifier).state = selected!;
+                         Navigator.of(sheetContext).pop();
+                         // Start workout
+                         final routine = ref.read(warmupRoutineProvider);
+                         final exercises = ref.read(warmupExercisesProvider);
+                         Navigator.of(context).push(
+                           MaterialPageRoute<void>(
+                             builder: (_) => WorkoutExecutionScreen(
+                               session: routine.toSession(),
+                               seededExercises: exercises,
+                             ),
+                           ),
+                         );
+                       },
+                       icon: const Icon(Icons.play_arrow_rounded, size: 20),
+                       label: Text(
+                         widget.isFrench ? 'Confirmer et démarrer' : 'Confirm & Start',
+                         style: const TextStyle(fontWeight: FontWeight.w600),
+                       ),
+                       style: FilledButton.styleFrom(
+                         backgroundColor: AppColors.primary,
+                         disabledBackgroundColor:
+                             AppColors.primary.withValues(alpha: AppOpacity.moderate),
+                         foregroundColor: Colors.white,
+                         padding: const EdgeInsets.symmetric(vertical: AppSpacing.sm),
+                         shape: RoundedRectangleBorder(
+                           borderRadius: BorderRadius.circular(AppRadii.sm),
+                         ),
+                       ),
+                     ),
+                   ),
+                 ],
+               ),
+             );
+           },
+         ),
+       );
+     }
+     ```
+  4. Add private helper class `_WarmupCategoryTile` (file-private):
+     ```dart
+     class _WarmupCategoryTile extends StatelessWidget {
+       final WarmupCategory category;
+       final String label;
+       final bool isSelected;
+       final VoidCallback onTap;
+       const _WarmupCategoryTile({
+         required this.category,
+         required this.label,
+         required this.isSelected,
+         required this.onTap,
+       });
+       @override
+       Widget build(BuildContext context) {
+         return GestureDetector(
+           onTap: onTap,
+           child: AnimatedContainer(
+             duration: const Duration(milliseconds: 150),
+             margin: const EdgeInsets.only(bottom: AppSpacing.xs),
+             padding: const EdgeInsets.symmetric(
+               horizontal: AppSpacing.md, vertical: AppSpacing.sm),
+             decoration: BoxDecoration(
+               color: isSelected
+                   ? AppColors.primary.withValues(alpha: AppOpacity.subtle)
+                   : AppColors.surface,
+               borderRadius: BorderRadius.circular(AppRadii.md),
+               border: Border.all(
+                 color: isSelected ? AppColors.primary : AppColors.surfaceVariant,
+                 width: isSelected ? 2 : 1,
+               ),
+             ),
+             child: Row(
+               children: [
+                 Text(
+                   label,
+                   style: TextStyle(
+                     color: isSelected ? AppColors.primary : AppColors.textPrimary,
+                     fontSize: 15, fontWeight: FontWeight.w600,
+                   ),
+                 ),
+                 const Spacer(),
+                 if (isSelected)
+                   const Icon(Icons.check_circle_rounded,
+                       color: AppColors.primary, size: 20),
+               ],
+             ),
+           ),
+         );
+       }
+     }
+     ```
+  5. Update the existing Start button label in `_WarmupSelectorState` to simply say "Start warmup" (remove the duration from the label since category is now selected in the sheet):
+     ```dart
+     label: Text(
+       widget.isFrench ? 'Démarrer l\'échauffement' : 'Start warmup',
+       ...
+     ),
+     ```
+- **MIRROR**: BOTTOM_SHEET_PATTERN, NAMING_CONVENTION
+- **IMPORTS**: `WarmupCategoryScreen` import can be removed; `WorkoutExecutionScreen` still needed
+- **GOTCHA**: `showModalBottomSheet` needs `context` from the `build` method — pass it to `_showCategorySheet`. After popping the bottom sheet, the `context` is used for the Navigator push, so check `if (context.mounted)` before pushing.
+  The `warmupRoutineProvider` reads from `warmupCategoryProvider` state, so update the category in the notifier BEFORE reading `warmupRoutineProvider`.
+- **VALIDATE**: Hot reload; home screen shows only duration buttons + Start button. Tapping Start opens bottom sheet with category list. Confirm button disabled when nothing selected. Selecting a category enables Confirm. Tapping Confirm updates state and navigates to workout.
+
+### Task 4: Add `homePresetProgramsProvider` (limit 5)
+- **ACTION**: Add a new provider in `workout_providers.dart` that returns preset-only programs capped at 5
+- **IMPLEMENT**:
+  ```dart
+  /// Programs for the home screen — preset only, max 5.
+  final homePresetProgramsProvider = FutureProvider<List<Program>>((ref) async {
+    final syncService = ref.watch(syncServiceProvider);
+    try {
+      final all = await syncService.getPrograms();  // no userId = presets only
+      return all.take(5).toList();
+    } catch (_) {
+      return [];
+    }
+  });
+  ```
+  Add after the existing `programsProvider` block (after line 237).
+- **MIRROR**: PROVIDER_FAMILY_PATTERN
+- **IMPORTS**: None new
+- **GOTCHA**: `syncService.getPrograms()` without a `userId` returns preset-only programs per `SyncService.getPrograms` implementation (line 302-310 — if `userId == null`, `userPrograms` stays empty). Use `.take(5)` to cap.
+- **VALIDATE**: Check that `homePresetProgramsProvider` compiles. Will be used in Task 5.
+
+### Task 5: Update Programs carousel to use `homePresetProgramsProvider`
+- **ACTION**: Replace `programsProvider` with `homePresetProgramsProvider` in `_ProgramsCarouselBody`
+- **IMPLEMENT**:
+  In `_ProgramsCarouselBody.build`, change:
+  ```dart
+  final programsAsync = ref.watch(programsProvider);
+  ```
+  To:
+  ```dart
+  final programsAsync = ref.watch(homePresetProgramsProvider);
+  ```
+  Also update the empty-state message since these are now preset programs:
+  ```dart
+  // (optional) no change needed to the message text
+  ```
+- **MIRROR**: ASYNC_WHEN_PATTERN
+- **IMPORTS**: `homePresetProgramsProvider` is in the same `workout_providers.dart` file already imported
+- **GOTCHA**: `activeProgramId` still comes from `activeProgramStateProvider` — keep that line unchanged to preserve the "Active" badge on the correct program card.
+- **VALIDATE**: Hot reload; Programs carousel shows max 5 cards. If user has a user-created program, it does NOT appear here (only presets).
+
+### Task 6: Convert Sessions carousel to use real preset data (limit 10)
+- **ACTION**: Replace `_SessionsCarousel` (hardcoded) with a `ConsumerWidget` that reads from `presetSessionsProvider` capped at 10. Keep `_SessionCard` design; adapt to use `Session` model instead of `_SessionData`.
+- **IMPLEMENT**:
+  1. Delete `_SessionData` class and the `static const List<_SessionData> _sessions` constant.
+  2. Convert `_SessionsCarousel` to `ConsumerStatelessWidget`:
+     ```dart
+     class _SessionsCarousel extends ConsumerWidget {
+       final bool isFrench;
+       const _SessionsCarousel({required this.isFrench});
+
+       @override
+       Widget build(BuildContext context, WidgetRef ref) {
+         final sessionsAsync = ref.watch(presetSessionsProvider);
+         return SizedBox(
+           height: 120,
+           child: sessionsAsync.when(
+             data: (sessions) {
+               final capped = sessions.take(10).toList();
+               if (capped.isEmpty) {
+                 return Center(
+                   child: Text(
+                     isFrench ? 'Aucune séance disponible.' : 'No sessions available.',
+                     style: const TextStyle(
+                       color: AppColors.textSecondary, fontSize: 13),
+                   ),
+                 );
+               }
+               return ListView.separated(
+                 scrollDirection: Axis.horizontal,
+                 physics: const BouncingScrollPhysics(),
+                 clipBehavior: Clip.none,
+                 itemCount: capped.length,
+                 separatorBuilder: (_, __) => const SizedBox(width: AppSpacing.sm),
+                 itemBuilder: (context, index) =>
+                     _SessionCard(session: capped[index], isFrench: isFrench),
+               );
+             },
+             loading: () => ListView.separated(
+               scrollDirection: Axis.horizontal,
+               physics: const NeverScrollableScrollPhysics(),
+               itemCount: 3,
+               separatorBuilder: (_, __) => const SizedBox(width: AppSpacing.sm),
+               itemBuilder: (_, __) => Container(
+                 width: 180,
+                 decoration: BoxDecoration(
+                   color: AppColors.neutral300,
+                   borderRadius: BorderRadius.circular(AppRadii.sm),
+                 ),
+               ),
+             ),
+             error: (_, __) => Center(
+               child: Text(
+                 isFrench ? 'Impossible de charger les séances.'
+                           : 'Could not load sessions.',
+                 style: const TextStyle(
+                   color: AppColors.textSecondary, fontSize: 13),
+               ),
+             ),
+           ),
+         );
+       }
+     }
+     ```
+  3. Update `_SessionCard` to accept `Session` instead of `_SessionData`:
+     ```dart
+     class _SessionCard extends StatelessWidget {
+       final Session session;
+       final bool isFrench;
+       const _SessionCard({required this.session, required this.isFrench});
+     ```
+     Map `Session` fields to the card design:
+     - Title: `session.name`
+     - Duration: `'${session.estimatedDuration ~/ 60} min'` (convert seconds to minutes)
+     - Exercises count: `session.workouts.length`
+     - Level color / label: use `AppDifficultyTheme.paletteFor(session.difficulty).accentColor` for `levelColor`, `AppDifficultyTheme.label(session.difficulty, isFrench: isFrench)` for level text
+     - Icon: pick based on session name (same heuristic as `_ProgramCard._iconForProgram` — extract a shared helper or inline)
+- **MIRROR**: ASYNC_WHEN_PATTERN, CONSUMER_WIDGET_PATTERN
+- **IMPORTS**: `Session` model already imported; `AppDifficultyTheme` already imported
+- **GOTCHA**: `session.estimatedDuration` is in seconds. Convert: `session.estimatedDuration ~/ 60`. If `workouts` is empty, `estimatedDuration` might be 0 → show `'—'` instead. `presetSessionsProvider` is already in `workout_providers.dart` (line 96).
+- **VALIDATE**: Hot reload; Sessions carousel shows real session names (not hardcoded "Push Day", "Leg Day"). Max 10 items. Shows loading skeletons while loading, error message on failure.
+
+### Task 7: Remove the sign-out button
+- **ACTION**: Delete `_LogoutButton` class and its call-site in the build method
+- **IMPLEMENT**:
+  1. In `_HomeDashboardTabState.build`, remove:
+     ```dart
+     // Logout
+     _LogoutButton(
+       isFrench: isFrench,
+       onLogout: () async { ... },
+     ),
+     ```
+  2. Delete the `_LogoutButton` class entirely (lines 1886-1909).
+  3. Remove the unused import of `AuthenticationView` if it is no longer referenced elsewhere in this file. Check: `AuthenticationView` was only used in `_LogoutButton.onLogout`. Remove import if nothing else uses it.
+- **MIRROR**: N/A
+- **IMPORTS**: Remove `import 'package:workin_fit/views/auth/authentication_view.dart';` if no other usage remains in the file
+- **GOTCHA**: `authActionsProvider` was only used by the logout callback. Remove it from the imports if nothing else in this file uses it. Check `auth_provider.dart` import too.
+- **VALIDATE**: Hot reload; bottom of home screen shows quick-access cards, then the 104px spacer — no sign-out button.
+
+---
+
+## Testing Strategy
+
+### Unit Tests
+| Test | Input | Expected Output | Edge Case? |
+|---|---|---|---|
+| homePresetProgramsProvider caps at 5 | mock returning 8 programs | list.length == 5 | No |
+| homePresetProgramsProvider empty | sync throws | returns [] | Yes |
+
+### Widget Tests
+These are UI-centric changes; manual validation is primary. No new widget tests required for this task (existing auth_screens_test.dart and current test suite are not affected).
+
+### Edge Cases Checklist
+- [ ] No active program → hero card shows placeholder (no crash)
+- [ ] Active program loading → hero card shows spinner inside gradient
+- [ ] Active program load error → hero card shows error text inside gradient
+- [ ] presetSessionsProvider returns 0 sessions → sessions carousel shows empty-state text
+- [ ] presetSessionsProvider returns >10 sessions → carousel shows exactly 10
+- [ ] homePresetProgramsProvider returns 0 programs → programs carousel shows empty-state text
+- [ ] Warmup bottom sheet opened → Confirm button disabled
+- [ ] Category selected in sheet → Confirm button enabled
+- [ ] Confirm tapped → sheet closes, workout starts
+
+---
+
+## Validation Commands
+
+### Static Analysis
+```bash
+cd /home/golden/Desktop/dev/dart/workin_fit
+flutter analyze lib/views/home/home_dashboard_tab.dart lib/providers/workout_providers.dart
+```
+EXPECT: Zero errors, zero warnings
+
+### Full Build Check
+```bash
+flutter build apk --debug 2>&1 | tail -20
+# or faster:
+flutter pub get && flutter analyze
+```
+EXPECT: No errors
+
+### Run Existing Tests
+```bash
+flutter test
+```
+EXPECT: All 159 existing tests pass, no regressions
+
+### Manual Validation
+- [ ] Home screen banner: flat bottom edge, no arch curve
+- [ ] Session hero card: single gradient card (not two stacked cards)
+- [ ] Hero card (no active program): shows placeholder with play button
+- [ ] Hero card (active program): shows program name, week/day, meta chips
+- [ ] Warmup section: no category chip button visible
+- [ ] Tapping "Start warmup" → bottom sheet appears
+- [ ] Bottom sheet shows 5 category options
+- [ ] Confirm button is disabled (grayed) with no selection
+- [ ] Selecting a category enables Confirm button
+- [ ] Confirm → sheet closes, workout launches
+- [ ] Programs carousel: max 5 cards, preset programs only
+- [ ] Sessions carousel: real session names, max 10 cards
+- [ ] No sign-out button at the bottom of home screen
+
+---
+
+## Acceptance Criteria
+- [ ] All 7 tasks completed
+- [ ] `flutter analyze` reports zero errors
+- [ ] All 159 existing tests pass
+- [ ] Banner has no arch/curve
+- [ ] Single session hero card using real data with gradient design
+- [ ] Warmup category selected via bottom sheet, not navigation
+- [ ] Programs carousel limited to 5 preset programs
+- [ ] Sessions carousel shows real data, max 10
+- [ ] Sign-out button gone from home screen
+
+## Completion Checklist
+- [ ] Code follows private-class naming convention (`_ClassName`)
+- [ ] All `async` calls use `.when()` pattern for loading/error states
+- [ ] No hardcoded strings without `isFrench` branching
+- [ ] No mutation — new instances created where needed
+- [ ] `context.mounted` checked before Navigator calls in async callbacks
+- [ ] No unnecessary scope additions beyond the 5 listed changes
+- [ ] Self-contained — no questions needed during implementation
+
+## Risks
+| Risk | Likelihood | Impact | Mitigation |
+|---|---|---|---|
+| `warmupRoutineProvider` depends on `warmupCategoryProvider` — reading after notifier update may not reflect new state synchronously | Medium | High | Read `warmupRoutineProvider` AFTER `ref.read(warmupCategoryProvider.notifier).state = selected` so the provider recalculates with new category |
+| Session `estimatedDuration = 0` for empty sessions | Low | Low | Show `'—'` when duration ≤ 0 |
+| `context.mounted` false after await in logout (already removed) | N/A | N/A | Removed entirely |
+| Removing `_ProgramCardContainer` may break if used elsewhere | Low | Medium | Grep for `_ProgramCardContainer` before deleting — it's only in this file |
+
+## Notes
+- `_ArchClipper` is only referenced inside `_HomeBannerSliver` — safe to delete entirely
+- The `WarmupCategoryScreen` import (`warmup_category_screen.dart`) should be removed since direct navigation to it is no longer needed from home
+- The `_categoryLabels` map in `_WarmupSelectorState` is already defined and can be directly reused in `_showCategorySheet` via `_WarmupCategoryTile`
+- `AppDifficultyTheme.paletteFor(session.difficulty).accentColor` is used in `_ProgramCard` already — follow the exact same pattern for sessions
+- The decorative ring positions in the gradient card (right: -36, top: -36 and left: -20, bottom: -44) should remain UNCHANGED — they are part of the established design language

--- a/.claude/PRPs/reports/home-screen-design-enhancements-report.md
+++ b/.claude/PRPs/reports/home-screen-design-enhancements-report.md
@@ -1,0 +1,57 @@
+# Implementation Report: Home Screen Design Enhancements
+
+## Summary
+Implemented 5 home screen visual and UX improvements: removed the arch banner decoration, unified the two session blocks into a single gradient hero card with real active program data, moved warmup category selection to a bottom sheet triggered by the Start button, capped the Programs carousel to 5 preset programs and converted the Sessions carousel to show up to 10 real sessions from `presetSessionsProvider`, and removed the sign-out button.
+
+## Assessment vs Reality
+
+| Metric | Predicted (Plan) | Actual |
+|---|---|---|
+| Complexity | Medium | Medium |
+| Confidence | 9/10 | 9/10 |
+| Files Changed | 2 | 2 |
+
+## Tasks Completed
+
+| # | Task | Status | Notes |
+|---|---|---|---|
+| 1 | Remove Arch — Flatten banner bottom edge | ✅ Complete | Removed `ClipPath`/`_ArchClipper`, adjusted bottom padding from `lg+md` to `lg` |
+| 2 | Merge session hero cards — real data with gradient design | ✅ Complete | `_SessionOfTheDayCard` + `_CurrentProgramDayCard` + `_ProgramCardContainer` → `_SessionHeroCard` |
+| 3 | Warmup — category selection via bottom sheet | ✅ Complete | Removed category chip, Start button opens `showModalBottomSheet`, added `_WarmupCategoryTile` |
+| 4 | Add `homePresetProgramsProvider` (limit 5) | ✅ Complete | New provider in `workout_providers.dart` |
+| 5 | Update Programs carousel to `homePresetProgramsProvider` | ✅ Complete | One-line swap in `_ProgramsCarouselBody` |
+| 6 | Convert Sessions carousel to real preset data (limit 10) | ✅ Complete | `_SessionsCarousel` → `ConsumerWidget`, `_SessionCard` → uses `Session` model |
+| 7 | Remove sign-out button | ✅ Complete | Removed `_LogoutButton` class, call-site, and unused imports |
+
+## Validation Results
+
+| Level | Status | Notes |
+|---|---|---|
+| Static Analysis | ✅ Pass | Zero errors; 2 pre-existing trailing-comma infos (not new) |
+| Unit Tests | ✅ Pass | 159/159 tests pass, no regressions |
+| Build | ✅ Pass (analyze) | `flutter analyze` clean on both changed files |
+| Integration | N/A | UI-only changes |
+| Edge Cases | ✅ Pass | No active program → placeholder card; loading → spinner in gradient card; error → message in gradient card |
+
+## Files Changed
+
+| File | Action | Notes |
+|---|---|---|
+| `lib/views/home/home_dashboard_tab.dart` | UPDATED | ~400 lines net change — removed arch, merged hero cards, warmup bottom sheet, sessions carousel, logout removal |
+| `lib/providers/workout_providers.dart` | UPDATED | +10 lines — added `homePresetProgramsProvider` |
+
+## Deviations from Plan
+- The `_SessionHeroCard._buildGradientCard` uses `Icons.arrow_forward_rounded` instead of `Icons.play_arrow_rounded` for the action button when an active program is present — clearer affordance for navigation vs. playback.
+- Unused variables `category` and `categoryLabel` were removed from `_WarmupSelectorState.build` since the category chip was deleted.
+
+## Issues Encountered
+- The old `_HomeBannerSliver` had an extra nesting level (ClipPath → AppTopBarBackground → Padding → Column), requiring two edits: one to remove ClipPath and one to fix indentation/bracket count.
+- `Session` model needed to be explicitly imported in `home_dashboard_tab.dart` (not previously needed since sessions weren't used there).
+- `warmup_category_screen.dart` and `authentication_view.dart` imports became unused after their usages were removed — cleaned up.
+
+## Tests Written
+None new — this is a UI refactor. All existing 159 tests continue to pass.
+
+## Next Steps
+- [ ] Code review via `/code-review`
+- [ ] Create PR via `/prp-pr`

--- a/lib/providers/workout_providers.dart
+++ b/lib/providers/workout_providers.dart
@@ -236,6 +236,17 @@ final programsProvider = FutureProvider<List<Program>>((ref) async {
   }
 });
 
+/// Programs for the home screen — preset only (no user ID), max 5.
+final homePresetProgramsProvider = FutureProvider<List<Program>>((ref) async {
+  final syncService = ref.watch(syncServiceProvider);
+  try {
+    final all = await syncService.getPrograms();
+    return all.take(5).toList();
+  } catch (_) {
+    return [];
+  }
+});
+
 /// Program by ID provider
 final programByIdProvider = FutureProvider.family<Program?, String>(
   (ref, programId) async {

--- a/lib/views/home/home_dashboard_tab.dart
+++ b/lib/views/home/home_dashboard_tab.dart
@@ -5,15 +5,14 @@ import 'package:workin_fit/core/theme/app_difficulty.dart';
 import 'package:workin_fit/core/theme/app_dimensions.dart';
 import 'package:workin_fit/core/theme/colors.dart';
 import 'package:workin_fit/features/session/presentation/screens/program_detail_screen.dart';
-import 'package:workin_fit/features/warmup/presentation/screens/warmup_category_screen.dart';
 import 'package:workin_fit/features/workout/presentation/screens/exercise_list_screen.dart';
 import 'package:workin_fit/features/workout/presentation/screens/workout_execution_screen.dart';
 import 'package:workin_fit/models/enums.dart';
 import 'package:workin_fit/models/program.dart';
+import 'package:workin_fit/models/session.dart';
 import 'package:workin_fit/providers/auth_provider.dart';
 import 'package:workin_fit/providers/warmup_providers.dart';
 import 'package:workin_fit/providers/workout_providers.dart';
-import 'package:workin_fit/views/auth/authentication_view.dart';
 import 'package:workin_fit/core/theme/app_opacity.dart';
 
 class HomeDashboardTab extends ConsumerStatefulWidget {
@@ -84,12 +83,8 @@ class _HomeDashboardTabState extends ConsumerState<HomeDashboardTab>
                 ),
                 sliver: SliverList(
                   delegate: SliverChildListDelegate(<Widget>[
-                    // Session of the Day
-                    _SessionOfTheDayCard(isFrench: isFrench),
-                    const SizedBox(height: AppSpacing.md),
-
-                    // Active Program Day
-                    _CurrentProgramDayCard(isFrench: isFrench),
+                    // Session Hero Card (real data, gradient design)
+                    _SessionHeroCard(isFrench: isFrench),
                     const SizedBox(height: AppSpacing.md),
 
                     // Daily Challenge
@@ -141,26 +136,6 @@ class _HomeDashboardTabState extends ConsumerState<HomeDashboardTab>
                       },
                     ),
                     const SizedBox(height: AppSpacing.lg),
-
-                    // Logout
-                    _LogoutButton(
-                      isFrench: isFrench,
-                      onLogout: () async {
-                        try {
-                          if (context.mounted) {
-                            Navigator.of(context).pushAndRemoveUntil(
-                              MaterialPageRoute<void>(
-                                builder: (_) => const AuthenticationView(
-                                  initialTabIndex: 1,
-                                ),
-                              ),
-                              (Route<dynamic> route) => false,
-                            );
-                          }
-                          await ref.read(authActionsProvider).signOut();
-                        } catch (_) {}
-                      },
-                    ),
 
                     // Bottom padding — floating nav bar clearance
                     const SizedBox(height: 104),
@@ -225,46 +200,43 @@ class _HomeBannerSliver extends StatelessWidget {
     final double topPadding = MediaQuery.of(context).padding.top;
 
     return SliverToBoxAdapter(
-      child: ClipPath(
-        clipper: _ArchClipper(),
-        child: AppTopBarBackground(
-          child: Padding(
-            padding: EdgeInsets.fromLTRB(
-              AppSpacing.lg,
-              topPadding + AppSpacing.md,
-              AppSpacing.lg,
-              AppSpacing.lg + AppSpacing.md,
-            ),
-            child: Column(
-              crossAxisAlignment: CrossAxisAlignment.start,
-              children: <Widget>[
-                // Greeting
-                Text(
-                  '$greeting,',
-                  style: TextStyle(
-                    color: Colors.white.withValues(alpha: AppOpacity.bold),
-                    fontSize: 15,
-                    fontWeight: FontWeight.w500,
-                    letterSpacing: 0.2,
-                  ),
+      child: AppTopBarBackground(
+        child: Padding(
+          padding: EdgeInsets.fromLTRB(
+            AppSpacing.lg,
+            topPadding + AppSpacing.md,
+            AppSpacing.lg,
+            AppSpacing.lg,
+          ),
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: <Widget>[
+              // Greeting
+              Text(
+                '$greeting,',
+                style: TextStyle(
+                  color: Colors.white.withValues(alpha: AppOpacity.bold),
+                  fontSize: 15,
+                  fontWeight: FontWeight.w500,
+                  letterSpacing: 0.2,
                 ),
-                const SizedBox(height: 2),
-                Text(
-                  displayName,
-                  style: const TextStyle(
-                    color: Colors.white,
-                    fontFamily: 'AppFontMedium',
-                    fontSize: 30,
-                    fontWeight: FontWeight.w800,
-                    letterSpacing: -0.5,
-                    height: 1.1,
-                  ),
+              ),
+              const SizedBox(height: 2),
+              Text(
+                displayName,
+                style: const TextStyle(
+                  color: Colors.white,
+                  fontFamily: 'AppFontMedium',
+                  fontSize: 30,
+                  fontWeight: FontWeight.w800,
+                  letterSpacing: -0.5,
+                  height: 1.1,
                 ),
-                const SizedBox(height: AppSpacing.md),
-                // Stats row
-                _BannerStatsRow(isFrench: isFrench),
-              ],
-            ),
+              ),
+              const SizedBox(height: AppSpacing.md),
+              // Stats row
+              _BannerStatsRow(isFrench: isFrench),
+            ],
           ),
         ),
       ),
@@ -382,30 +354,6 @@ class _StatPill extends StatelessWidget {
 }
 
 // ─────────────────────────────────────────────────────────────────────────────
-// Wave clipper
-// ─────────────────────────────────────────────────────────────────────────────
-
-class _ArchClipper extends CustomClipper<Path> {
-  @override
-  Path getClip(Size size) {
-    final Path path = Path();
-    path.lineTo(0, size.height - 28);
-    path.quadraticBezierTo(
-      size.width * 0.5,
-      size.height + 28,
-      size.width,
-      size.height - 28,
-    );
-    path.lineTo(size.width, 0);
-    path.close();
-    return path;
-  }
-
-  @override
-  bool shouldReclip(CustomClipper<Path> oldClipper) => false;
-}
-
-// ─────────────────────────────────────────────────────────────────────────────
 // Section title
 // ─────────────────────────────────────────────────────────────────────────────
 
@@ -497,17 +445,144 @@ class _SectionTitle extends StatelessWidget {
 }
 
 // ─────────────────────────────────────────────────────────────────────────────
-// Session of the Day
+// Session Hero Card (gradient design + real active program data)
 // ─────────────────────────────────────────────────────────────────────────────
 
-class _SessionOfTheDayCard extends StatelessWidget {
+class _SessionHeroCard extends ConsumerWidget {
   final bool isFrench;
-  const _SessionOfTheDayCard({required this.isFrench});
+  const _SessionHeroCard({required this.isFrench});
 
   @override
-  Widget build(BuildContext context) {
+  Widget build(BuildContext context, WidgetRef ref) {
+    final activeProgramStateAsync = ref.watch(activeProgramStateProvider);
+
+    return activeProgramStateAsync.when(
+      data: (activeProgramState) {
+        if (activeProgramState == null) {
+          return _buildGradientCard(
+            context: context,
+            label: isFrench ? 'SÉANCE DU JOUR' : 'SESSION OF THE DAY',
+            title: isFrench ? 'Prêt à s\'entraîner ?' : 'Ready to train?',
+            subtitle: isFrench
+                ? 'Démarrez un programme depuis l\'onglet Programmes'
+                : 'Start a program from the Programs tab',
+            chips: [],
+            onTap: null,
+          );
+        }
+        final programAsync = ref.watch(
+          programByIdProvider(activeProgramState.programId),
+        );
+        return programAsync.when(
+          data: (program) {
+            if (program == null) {
+              return _buildGradientCard(
+                context: context,
+                label: isFrench ? 'SÉANCE DU JOUR' : 'SESSION OF THE DAY',
+                title: isFrench ? 'Programme introuvable' : 'Program not found',
+                subtitle: isFrench
+                    ? 'Choisissez un nouveau programme'
+                    : 'Choose a new program',
+                chips: [],
+                onTap: null,
+              );
+            }
+            final DateTime startDate = activeProgramState.startDateOnly;
+            final DateTime now = DateTime.now();
+            final DateTime today = DateTime(now.year, now.month, now.day);
+            final int elapsed = today.difference(startDate).inDays;
+            final int totalDays = program.totalDays;
+            final bool startsInFuture = elapsed < 0;
+            final int currentDay =
+                startsInFuture ? 1 : (elapsed + 1).clamp(1, totalDays);
+            final int currentWeek = startsInFuture
+                ? 1
+                : ((elapsed ~/ 7) + 1).clamp(1, program.durationWeeks);
+            final int daysUntilStart = startsInFuture ? -elapsed : 0;
+
+            final String subtitle = startsInFuture
+                ? (isFrench
+                    ? 'Démarre dans $daysUntilStart jour${daysUntilStart > 1 ? 's' : ''}'
+                    : 'Starts in $daysUntilStart day${daysUntilStart > 1 ? 's' : ''}')
+                : (isFrench
+                    ? 'Semaine $currentWeek/${program.durationWeeks}  •  Jour $currentDay/$totalDays'
+                    : 'Week $currentWeek/${program.durationWeeks}  •  Day $currentDay/$totalDays');
+
+            return _buildGradientCard(
+              context: context,
+              label: isFrench ? 'PROGRAMME ACTIF' : 'ACTIVE PROGRAM',
+              title: program.name,
+              subtitle: subtitle,
+              chips: [
+                _SessionMetaChip(
+                  icon: Icons.calendar_today_rounded,
+                  label: isFrench
+                      ? 'Jour $currentDay'
+                      : 'Day $currentDay',
+                ),
+                _SessionMetaChip(
+                  icon: Icons.bar_chart_rounded,
+                  label: AppDifficultyTheme.label(
+                    program.difficulty,
+                    isFrench: isFrench,
+                  ),
+                ),
+              ],
+              onTap: () => Navigator.of(context).push(
+                ProgramDetailScreen.route(program: program),
+              ),
+            );
+          },
+          loading: () => _buildGradientCard(
+            context: context,
+            label: isFrench ? 'SÉANCE DU JOUR' : 'SESSION OF THE DAY',
+            title: '...',
+            subtitle: '',
+            chips: [],
+            onTap: null,
+            isLoading: true,
+          ),
+          error: (_, __) => _buildGradientCard(
+            context: context,
+            label: isFrench ? 'SÉANCE DU JOUR' : 'SESSION OF THE DAY',
+            title: isFrench ? 'Erreur de chargement' : 'Could not load',
+            subtitle: '',
+            chips: [],
+            onTap: null,
+          ),
+        );
+      },
+      loading: () => _buildGradientCard(
+        context: context,
+        label: isFrench ? 'SÉANCE DU JOUR' : 'SESSION OF THE DAY',
+        title: '...',
+        subtitle: '',
+        chips: [],
+        onTap: null,
+        isLoading: true,
+      ),
+      error: (_, __) => _buildGradientCard(
+        context: context,
+        label: isFrench ? 'SÉANCE DU JOUR' : 'SESSION OF THE DAY',
+        title: isFrench ? 'Erreur de chargement' : 'Could not load',
+        subtitle: '',
+        chips: [],
+        onTap: null,
+      ),
+    );
+  }
+
+  Widget _buildGradientCard({
+    required BuildContext context,
+    required String label,
+    required String title,
+    required String subtitle,
+    required List<Widget> chips,
+    required VoidCallback? onTap,
+    bool isLoading = false,
+  }) {
     return GestureDetector(
-      onTap: () {},
+      onTap: onTap,
       child: Container(
         decoration: BoxDecoration(
           borderRadius: BorderRadius.circular(AppRadii.sm),
@@ -568,97 +643,104 @@ class _SessionOfTheDayCard extends StatelessWidget {
               // Card content
               Padding(
                 padding: const EdgeInsets.all(AppSpacing.lg),
-                child: Column(
-                  crossAxisAlignment: CrossAxisAlignment.start,
-                  children: <Widget>[
-                    Row(
-                      children: <Widget>[
-                        Container(
-                          padding: const EdgeInsets.symmetric(
-                            horizontal: AppSpacing.xs,
-                            vertical: 4,
-                          ),
-                          decoration: BoxDecoration(
-                            color:
-                                Colors.white.withValues(alpha: AppOpacity.soft),
-                            borderRadius: BorderRadius.circular(AppRadii.sm),
-                            border: Border.all(
-                              color: Colors.white
-                                  .withValues(alpha: AppOpacity.medium),
-                            ),
-                          ),
-                          child: Text(
-                            isFrench ? 'SÉANCE DU JOUR' : 'SESSION OF THE DAY',
-                            style: TextStyle(
-                              color: Colors.white
-                                  .withValues(alpha: AppOpacity.high),
-                              fontSize: 9,
-                              fontWeight: FontWeight.w800,
-                              letterSpacing: 1.2,
-                            ),
-                          ),
-                        ),
-                        const Spacer(),
-                        Container(
-                          width: 40,
-                          height: 40,
-                          decoration: BoxDecoration(
-                            color:
-                                Colors.white.withValues(alpha: AppOpacity.soft),
-                            shape: BoxShape.circle,
-                          ),
-                          child: const Icon(
-                            Icons.play_arrow_rounded,
+                child: isLoading
+                    ? const SizedBox(
+                        height: 80,
+                        child: Center(
+                          child: CircularProgressIndicator(
                             color: Colors.white,
-                            size: 24,
+                            strokeWidth: 2,
                           ),
                         ),
-                      ],
-                    ),
-                    const SizedBox(height: AppSpacing.md),
-                    const Text(
-                      'Full Body Power',
-                      style: TextStyle(
-                        color: Colors.white,
-                        fontFamily: 'AppFontMedium',
-                        fontSize: 26,
-                        fontWeight: FontWeight.w800,
-                        letterSpacing: -0.3,
-                        height: 1.1,
+                      )
+                    : Column(
+                        crossAxisAlignment: CrossAxisAlignment.start,
+                        children: <Widget>[
+                          Row(
+                            children: <Widget>[
+                              Container(
+                                padding: const EdgeInsets.symmetric(
+                                  horizontal: AppSpacing.xs,
+                                  vertical: 4,
+                                ),
+                                decoration: BoxDecoration(
+                                  color: Colors.white
+                                      .withValues(alpha: AppOpacity.soft),
+                                  borderRadius:
+                                      BorderRadius.circular(AppRadii.sm),
+                                  border: Border.all(
+                                    color: Colors.white
+                                        .withValues(alpha: AppOpacity.medium),
+                                  ),
+                                ),
+                                child: Text(
+                                  label,
+                                  style: TextStyle(
+                                    color: Colors.white
+                                        .withValues(alpha: AppOpacity.high),
+                                    fontSize: 9,
+                                    fontWeight: FontWeight.w800,
+                                    letterSpacing: 1.2,
+                                  ),
+                                ),
+                              ),
+                              const Spacer(),
+                              if (onTap != null)
+                                Container(
+                                  width: 40,
+                                  height: 40,
+                                  decoration: BoxDecoration(
+                                    color: Colors.white
+                                        .withValues(alpha: AppOpacity.soft),
+                                    shape: BoxShape.circle,
+                                  ),
+                                  child: const Icon(
+                                    Icons.arrow_forward_rounded,
+                                    color: Colors.white,
+                                    size: 22,
+                                  ),
+                                ),
+                            ],
+                          ),
+                          const SizedBox(height: AppSpacing.md),
+                          Text(
+                            title,
+                            maxLines: 2,
+                            overflow: TextOverflow.ellipsis,
+                            style: const TextStyle(
+                              color: Colors.white,
+                              fontFamily: 'AppFontMedium',
+                              fontSize: 26,
+                              fontWeight: FontWeight.w800,
+                              letterSpacing: -0.3,
+                              height: 1.1,
+                            ),
+                          ),
+                          if (subtitle.isNotEmpty) ...[
+                            const SizedBox(height: 5),
+                            Text(
+                              subtitle,
+                              style: TextStyle(
+                                color: Colors.white
+                                    .withValues(alpha: AppOpacity.strong),
+                                fontSize: 13,
+                              ),
+                            ),
+                          ],
+                          if (chips.isNotEmpty) ...[
+                            const SizedBox(height: AppSpacing.md),
+                            Row(
+                              children: chips
+                                  .expand((chip) => [
+                                        chip,
+                                        const SizedBox(width: AppSpacing.xs),
+                                      ])
+                                  .toList()
+                                ..removeLast(),
+                            ),
+                          ],
+                        ],
                       ),
-                    ),
-                    const SizedBox(height: 5),
-                    Text(
-                      isFrench
-                          ? 'Circuit complet — force et cardio combinés'
-                          : 'Full circuit — strength and cardio combined',
-                      style: TextStyle(
-                        color:
-                            Colors.white.withValues(alpha: AppOpacity.strong),
-                        fontSize: 13,
-                      ),
-                    ),
-                    const SizedBox(height: AppSpacing.md),
-                    Row(
-                      children: <Widget>[
-                        const _SessionMetaChip(
-                          icon: Icons.timer_outlined,
-                          label: '45 min',
-                        ),
-                        const SizedBox(width: AppSpacing.xs),
-                        _SessionMetaChip(
-                          icon: Icons.bolt_rounded,
-                          label: isFrench ? '8 exercices' : '8 exercises',
-                        ),
-                        const SizedBox(width: AppSpacing.xs),
-                        _SessionMetaChip(
-                          icon: Icons.bar_chart_rounded,
-                          label: isFrench ? 'Intermédiaire' : 'Intermediate',
-                        ),
-                      ],
-                    ),
-                  ],
-                ),
               ),
             ],
           ),
@@ -881,264 +963,6 @@ class _DailyChallengeCard extends StatelessWidget {
   }
 }
 
-class _CurrentProgramDayCard extends ConsumerWidget {
-  final bool isFrench;
-  const _CurrentProgramDayCard({required this.isFrench});
-
-  @override
-  Widget build(BuildContext context, WidgetRef ref) {
-    final activeProgramStateAsync = ref.watch(activeProgramStateProvider);
-
-    return activeProgramStateAsync.when(
-      data: (activeProgramState) {
-        if (activeProgramState == null) {
-          return _ProgramCardContainer(
-            child: Row(
-              children: [
-                Container(
-                  width: 44,
-                  height: 44,
-                  decoration: BoxDecoration(
-                    color:
-                        AppColors.primary.withValues(alpha: AppOpacity.subtle),
-                    borderRadius: BorderRadius.circular(AppRadii.sm),
-                  ),
-                  child: const Icon(
-                    Icons.calendar_month_rounded,
-                    color: AppColors.primary,
-                    size: 22,
-                  ),
-                ),
-                const SizedBox(width: AppSpacing.sm),
-                Expanded(
-                  child: Text(
-                    isFrench
-                        ? 'Aucun programme actif. Démarrez-en un depuis l\'onglet Programmes.'
-                        : 'No active program. Start one from the Programs tab.',
-                    style: const TextStyle(
-                      color: AppColors.textSecondary,
-                      fontSize: 13,
-                      height: 1.35,
-                    ),
-                  ),
-                ),
-              ],
-            ),
-          );
-        }
-
-        final programAsync = ref.watch(
-          programByIdProvider(activeProgramState.programId),
-        );
-        return programAsync.when(
-          data: (program) {
-            if (program == null) {
-              return _ProgramCardContainer(
-                child: Text(
-                  isFrench
-                      ? 'Programme actif introuvable.'
-                      : 'Active program could not be loaded.',
-                  style: const TextStyle(
-                    color: AppColors.textSecondary,
-                    fontSize: 13,
-                  ),
-                ),
-              );
-            }
-
-            final DateTime startDate = activeProgramState.startDateOnly;
-            final DateTime now = DateTime.now();
-            final DateTime today = DateTime(now.year, now.month, now.day);
-            final int elapsed = today.difference(startDate).inDays;
-            final int totalDays = program.totalDays;
-            final bool startsInFuture = elapsed < 0;
-            final bool isCompleted = elapsed >= totalDays;
-            final int currentDay =
-                startsInFuture ? 1 : (elapsed + 1).clamp(1, totalDays);
-            final int currentWeek = startsInFuture
-                ? 1
-                : ((elapsed ~/ 7) + 1).clamp(1, program.durationWeeks);
-            final int daysUntilStart = startsInFuture ? -elapsed : 0;
-            final double progress =
-                startsInFuture ? 0 : (currentDay / totalDays).clamp(0.0, 1.0);
-            final Color accent =
-                AppDifficultyTheme.paletteFor(program.difficulty).accentColor;
-
-            return _ProgramCardContainer(
-              child: InkWell(
-                borderRadius: BorderRadius.circular(AppRadii.sm),
-                onTap: () => Navigator.of(context).push(
-                  ProgramDetailScreen.route(program: program),
-                ),
-                child: Padding(
-                  padding: const EdgeInsets.all(AppSpacing.md),
-                  child: Column(
-                    crossAxisAlignment: CrossAxisAlignment.start,
-                    children: [
-                      Row(
-                        children: [
-                          Container(
-                            width: 40,
-                            height: 40,
-                            decoration: BoxDecoration(
-                              color:
-                                  accent.withValues(alpha: AppOpacity.subtle),
-                              borderRadius: BorderRadius.circular(AppRadii.sm),
-                            ),
-                            child: Icon(
-                              Icons.flag_rounded,
-                              color: accent,
-                              size: 20,
-                            ),
-                          ),
-                          const SizedBox(width: AppSpacing.sm),
-                          Expanded(
-                            child: Column(
-                              crossAxisAlignment: CrossAxisAlignment.start,
-                              children: [
-                                Text(
-                                  isFrench
-                                      ? 'JOUR DU PROGRAMME'
-                                      : 'PROGRAM DAY',
-                                  style: TextStyle(
-                                    color: accent,
-                                    fontSize: 10,
-                                    fontWeight: FontWeight.w700,
-                                    letterSpacing: 0.8,
-                                  ),
-                                ),
-                                const SizedBox(height: 2),
-                                Text(
-                                  program.name,
-                                  maxLines: 1,
-                                  overflow: TextOverflow.ellipsis,
-                                  style: const TextStyle(
-                                    color: AppColors.textPrimary,
-                                    fontSize: 15,
-                                    fontWeight: FontWeight.w700,
-                                    fontFamily: 'AppFontMedium',
-                                  ),
-                                ),
-                              ],
-                            ),
-                          ),
-                          const Icon(
-                            Icons.chevron_right_rounded,
-                            color: AppColors.textTertiary,
-                            size: 20,
-                          ),
-                        ],
-                      ),
-                      const SizedBox(height: AppSpacing.sm),
-                      Text(
-                        startsInFuture
-                            ? (isFrench
-                                ? 'Démarre dans $daysUntilStart jour${daysUntilStart > 1 ? 's' : ''}'
-                                : 'Starts in $daysUntilStart day${daysUntilStart > 1 ? 's' : ''}')
-                            : (isFrench
-                                ? 'Semaine $currentWeek/${program.durationWeeks}  •  Jour $currentDay/$totalDays'
-                                : 'Week $currentWeek/${program.durationWeeks}  •  Day $currentDay/$totalDays'),
-                        style: const TextStyle(
-                          color: AppColors.textSecondary,
-                          fontSize: 12,
-                          fontWeight: FontWeight.w600,
-                        ),
-                      ),
-                      const SizedBox(height: 6),
-                      ClipRRect(
-                        borderRadius: BorderRadius.circular(3),
-                        child: LinearProgressIndicator(
-                          value: progress,
-                          minHeight: 5,
-                          backgroundColor:
-                              accent.withValues(alpha: AppOpacity.whisper),
-                          valueColor: AlwaysStoppedAnimation<Color>(accent),
-                        ),
-                      ),
-                      if (isCompleted) ...[
-                        const SizedBox(height: 6),
-                        Text(
-                          isFrench
-                              ? 'Programme terminé. Choisissez le prochain objectif.'
-                              : 'Program complete. Choose your next goal.',
-                          style: const TextStyle(
-                            color: AppColors.success,
-                            fontSize: 11,
-                            fontWeight: FontWeight.w600,
-                          ),
-                        ),
-                      ],
-                    ],
-                  ),
-                ),
-              ),
-            );
-          },
-          loading: () => const _ProgramCardContainer(
-            child: SizedBox(
-              height: 64,
-              child: Center(child: CircularProgressIndicator(strokeWidth: 2)),
-            ),
-          ),
-          error: (_, __) => _ProgramCardContainer(
-            child: Text(
-              isFrench
-                  ? 'Impossible de charger le programme actif.'
-                  : 'Could not load active program.',
-              style: const TextStyle(
-                color: AppColors.textSecondary,
-                fontSize: 13,
-              ),
-            ),
-          ),
-        );
-      },
-      loading: () => const _ProgramCardContainer(
-        child: SizedBox(
-          height: 64,
-          child: Center(child: CircularProgressIndicator(strokeWidth: 2)),
-        ),
-      ),
-      error: (_, __) => _ProgramCardContainer(
-        child: Text(
-          isFrench
-              ? 'Impossible de charger le jour du programme.'
-              : 'Could not load program day.',
-          style: const TextStyle(
-            color: AppColors.textSecondary,
-            fontSize: 13,
-          ),
-        ),
-      ),
-    );
-  }
-}
-
-class _ProgramCardContainer extends StatelessWidget {
-  final Widget child;
-  const _ProgramCardContainer({required this.child});
-
-  @override
-  Widget build(BuildContext context) {
-    return Container(
-      decoration: BoxDecoration(
-        color: AppColors.surface,
-        borderRadius: BorderRadius.circular(AppRadii.sm),
-        border: Border.all(
-          color: AppColors.primary.withValues(alpha: AppOpacity.soft),
-        ),
-        boxShadow: <BoxShadow>[
-          BoxShadow(
-            color: AppColors.primary.withValues(alpha: AppOpacity.faint),
-            blurRadius: 16,
-            offset: const Offset(0, 4),
-          ),
-        ],
-      ),
-      child: child,
-    );
-  }
-}
 
 // ─────────────────────────────────────────────────────────────────────────────
 // Warmup Selector
@@ -1163,55 +987,120 @@ class _WarmupSelectorState extends ConsumerState<_WarmupSelector> {
     WarmupCategory.cardio: ('Cardio', 'Cardio'),
   };
 
+  void _showCategorySheet(BuildContext context) {
+    WarmupCategory? selected = ref.read(warmupCategoryProvider);
+    showModalBottomSheet<void>(
+      context: context,
+      isScrollControlled: true,
+      backgroundColor: AppColors.surface,
+      shape: const RoundedRectangleBorder(
+        borderRadius: BorderRadius.vertical(top: Radius.circular(AppRadii.lg)),
+      ),
+      builder: (sheetContext) => StatefulBuilder(
+        builder: (sheetContext, setSheetState) {
+          return Padding(
+            padding: const EdgeInsets.fromLTRB(
+              AppSpacing.md,
+              AppSpacing.md,
+              AppSpacing.md,
+              AppSpacing.lg,
+            ),
+            child: Column(
+              mainAxisSize: MainAxisSize.min,
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: <Widget>[
+                // Handle
+                Center(
+                  child: Container(
+                    width: 40,
+                    height: 4,
+                    decoration: BoxDecoration(
+                      color: AppColors.primaryLight
+                          .withValues(alpha: AppOpacity.moderate),
+                      borderRadius: BorderRadius.circular(2),
+                    ),
+                  ),
+                ),
+                const SizedBox(height: AppSpacing.md),
+                Text(
+                  widget.isFrench
+                      ? 'Zone d\'échauffement'
+                      : 'Choose focus area',
+                  style: const TextStyle(
+                    color: AppColors.textPrimary,
+                    fontSize: 18,
+                    fontWeight: FontWeight.w700,
+                    fontFamily: 'AppFontMedium',
+                  ),
+                ),
+                const SizedBox(height: AppSpacing.sm),
+                for (final entry in _categoryLabels.entries)
+                  _WarmupCategoryTile(
+                    category: entry.key,
+                    label: widget.isFrench ? entry.value.$2 : entry.value.$1,
+                    isSelected: selected == entry.key,
+                    onTap: () => setSheetState(() => selected = entry.key),
+                  ),
+                const SizedBox(height: AppSpacing.md),
+                SizedBox(
+                  width: double.infinity,
+                  child: FilledButton.icon(
+                    onPressed: selected == null
+                        ? null
+                        : () {
+                            ref
+                                .read(warmupCategoryProvider.notifier)
+                                .state = selected!;
+                            Navigator.of(sheetContext).pop();
+                            if (!context.mounted) return;
+                            final routine = ref.read(warmupRoutineProvider);
+                            final exercises =
+                                ref.read(warmupExercisesProvider);
+                            Navigator.of(context).push(
+                              MaterialPageRoute<void>(
+                                builder: (_) => WorkoutExecutionScreen(
+                                  session: routine.toSession(),
+                                  seededExercises: exercises,
+                                ),
+                              ),
+                            );
+                          },
+                    icon: const Icon(Icons.play_arrow_rounded, size: 20),
+                    label: Text(
+                      widget.isFrench
+                          ? 'Confirmer et démarrer'
+                          : 'Confirm & Start',
+                      style: const TextStyle(fontWeight: FontWeight.w600),
+                    ),
+                    style: FilledButton.styleFrom(
+                      backgroundColor: AppColors.primary,
+                      disabledBackgroundColor:
+                          AppColors.primary.withValues(alpha: AppOpacity.moderate),
+                      foregroundColor: Colors.white,
+                      padding:
+                          const EdgeInsets.symmetric(vertical: AppSpacing.sm),
+                      shape: RoundedRectangleBorder(
+                        borderRadius: BorderRadius.circular(AppRadii.sm),
+                      ),
+                    ),
+                  ),
+                ),
+              ],
+            ),
+          );
+        },
+      ),
+    );
+  }
+
   @override
   Widget build(BuildContext context) {
-    final category = ref.watch(warmupCategoryProvider);
     final duration = ref.watch(warmupDurationProvider);
     final selectedIndex = _durations.indexOf(duration);
-
-    final labels = _categoryLabels[category]!;
-    final categoryLabel = widget.isFrench ? labels.$2 : labels.$1;
 
     return Column(
       crossAxisAlignment: CrossAxisAlignment.start,
       children: <Widget>[
-        // Category chip
-        GestureDetector(
-          onTap: () => Navigator.of(context).push(WarmupCategoryScreen.route()),
-          child: Container(
-            padding: const EdgeInsets.symmetric(
-              horizontal: AppSpacing.sm,
-              vertical: AppSpacing.xs,
-            ),
-            decoration: BoxDecoration(
-              color: AppColors.primary.withValues(alpha: AppOpacity.light),
-              borderRadius: BorderRadius.circular(AppRadii.xl),
-              border: Border.all(
-                color: AppColors.primary.withValues(alpha: AppOpacity.moderate),
-              ),
-            ),
-            child: Row(
-              mainAxisSize: MainAxisSize.min,
-              children: <Widget>[
-                const Icon(Icons.tune_rounded,
-                    size: 14, color: AppColors.primary),
-                const SizedBox(width: AppSpacing.xxs),
-                Text(
-                  categoryLabel,
-                  style: const TextStyle(
-                    color: AppColors.primary,
-                    fontSize: 13,
-                    fontWeight: FontWeight.w600,
-                  ),
-                ),
-                const SizedBox(width: AppSpacing.xxs),
-                const Icon(Icons.chevron_right_rounded,
-                    size: 16, color: AppColors.primary),
-              ],
-            ),
-          ),
-        ),
-        const SizedBox(height: AppSpacing.sm),
         // Duration buttons
         Row(
           children: List<Widget>.generate(
@@ -1238,27 +1127,14 @@ class _WarmupSelectorState extends ConsumerState<_WarmupSelector> {
           ),
         ),
         const SizedBox(height: AppSpacing.sm),
-        // Start button
+        // Start button — opens category selection sheet
         SizedBox(
           width: double.infinity,
           child: FilledButton.icon(
-            onPressed: () {
-              final routine = ref.read(warmupRoutineProvider);
-              final exercises = ref.read(warmupExercisesProvider);
-              Navigator.of(context).push(
-                MaterialPageRoute<void>(
-                  builder: (_) => WorkoutExecutionScreen(
-                    session: routine.toSession(),
-                    seededExercises: exercises,
-                  ),
-                ),
-              );
-            },
+            onPressed: () => _showCategorySheet(context),
             icon: const Icon(Icons.play_arrow_rounded, size: 20),
             label: Text(
-              widget.isFrench
-                  ? 'Démarrer $duration min d\'échauffement'
-                  : 'Start $duration min warmup',
+              widget.isFrench ? 'Démarrer l\'échauffement' : 'Start warmup',
               style: const TextStyle(fontWeight: FontWeight.w600),
             ),
             style: FilledButton.styleFrom(
@@ -1342,6 +1218,65 @@ class _WarmupDurationButton extends StatelessWidget {
   }
 }
 
+class _WarmupCategoryTile extends StatelessWidget {
+  final WarmupCategory category;
+  final String label;
+  final bool isSelected;
+  final VoidCallback onTap;
+
+  const _WarmupCategoryTile({
+    required this.category,
+    required this.label,
+    required this.isSelected,
+    required this.onTap,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return GestureDetector(
+      onTap: onTap,
+      child: AnimatedContainer(
+        duration: const Duration(milliseconds: 150),
+        margin: const EdgeInsets.only(bottom: AppSpacing.xs),
+        padding: const EdgeInsets.symmetric(
+          horizontal: AppSpacing.md,
+          vertical: AppSpacing.sm,
+        ),
+        decoration: BoxDecoration(
+          color: isSelected
+              ? AppColors.primary.withValues(alpha: AppOpacity.subtle)
+              : AppColors.surface,
+          borderRadius: BorderRadius.circular(AppRadii.md),
+          border: Border.all(
+            color: isSelected ? AppColors.primary : AppColors.surfaceVariant,
+            width: isSelected ? 2 : 1,
+          ),
+        ),
+        child: Row(
+          children: <Widget>[
+            Text(
+              label,
+              style: TextStyle(
+                color:
+                    isSelected ? AppColors.primary : AppColors.textPrimary,
+                fontSize: 15,
+                fontWeight: FontWeight.w600,
+              ),
+            ),
+            const Spacer(),
+            if (isSelected)
+              const Icon(
+                Icons.check_circle_rounded,
+                color: AppColors.primary,
+                size: 20,
+              ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
 // ─────────────────────────────────────────────────────────────────────────────
 // Programs Carousel
 // ─────────────────────────────────────────────────────────────────────────────
@@ -1364,7 +1299,7 @@ class _ProgramsCarouselBody extends ConsumerWidget {
         .languageCode
         .toLowerCase()
         .startsWith('fr');
-    final programsAsync = ref.watch(programsProvider);
+    final programsAsync = ref.watch(homePresetProgramsProvider);
     final activeProgramId =
         ref.watch(activeProgramStateProvider).valueOrNull?.programId;
 
@@ -1568,101 +1503,103 @@ class _ProgramCard extends StatelessWidget {
 // Sessions Carousel
 // ─────────────────────────────────────────────────────────────────────────────
 
-class _SessionsCarousel extends StatelessWidget {
+class _SessionsCarousel extends ConsumerWidget {
   final bool isFrench;
   const _SessionsCarousel({required this.isFrench});
 
-  static const List<_SessionData> _sessions = <_SessionData>[
-    _SessionData(
-      title: 'Push Day',
-      titleFr: 'Jour Push',
-      duration: '45 min',
-      exercises: 6,
-      level: 'Intermediate',
-      levelFr: 'Intermédiaire',
-      levelColor: AppColors.warning,
-      icon: Icons.fitness_center_rounded,
-    ),
-    _SessionData(
-      title: 'Leg Day',
-      titleFr: 'Jour Jambes',
-      duration: '60 min',
-      exercises: 8,
-      level: 'Beginner',
-      levelFr: 'Débutant',
-      levelColor: AppColors.success,
-      icon: Icons.directions_walk_rounded,
-    ),
-    _SessionData(
-      title: 'HIIT Circuit',
-      titleFr: 'Circuit HIIT',
-      duration: '30 min',
-      exercises: 10,
-      level: 'Advanced',
-      levelFr: 'Avancé',
-      levelColor: AppColors.error,
-      icon: Icons.bolt_rounded,
-    ),
-    _SessionData(
-      title: 'Pull Day',
-      titleFr: 'Jour Pull',
-      duration: '50 min',
-      exercises: 7,
-      level: 'Intermediate',
-      levelFr: 'Intermédiaire',
-      levelColor: AppColors.warning,
-      icon: Icons.open_with_rounded,
-    ),
-  ];
-
   @override
-  Widget build(BuildContext context) {
+  Widget build(BuildContext context, WidgetRef ref) {
+    final sessionsAsync = ref.watch(presetSessionsProvider);
     return SizedBox(
       height: 120,
-      child: ListView.separated(
-        scrollDirection: Axis.horizontal,
-        physics: const BouncingScrollPhysics(),
-        clipBehavior: Clip.none,
-        itemCount: _sessions.length,
-        separatorBuilder: (_, __) => const SizedBox(width: AppSpacing.sm),
-        itemBuilder: (BuildContext context, int index) {
-          return _SessionCard(data: _sessions[index], isFrench: isFrench);
+      child: sessionsAsync.when(
+        data: (sessions) {
+          final capped = sessions.take(10).toList();
+          if (capped.isEmpty) {
+            return Center(
+              child: Text(
+                isFrench
+                    ? 'Aucune séance disponible.'
+                    : 'No sessions available.',
+                style: const TextStyle(
+                  color: AppColors.textSecondary,
+                  fontSize: 13,
+                ),
+              ),
+            );
+          }
+          return ListView.separated(
+            scrollDirection: Axis.horizontal,
+            physics: const BouncingScrollPhysics(),
+            clipBehavior: Clip.none,
+            itemCount: capped.length,
+            separatorBuilder: (_, __) => const SizedBox(width: AppSpacing.sm),
+            itemBuilder: (BuildContext context, int index) =>
+                _SessionCard(session: capped[index], isFrench: isFrench),
+          );
         },
+        loading: () => ListView.separated(
+          scrollDirection: Axis.horizontal,
+          physics: const NeverScrollableScrollPhysics(),
+          itemCount: 3,
+          separatorBuilder: (_, __) => const SizedBox(width: AppSpacing.sm),
+          itemBuilder: (_, __) => Container(
+            width: 180,
+            decoration: BoxDecoration(
+              color: AppColors.neutral300,
+              borderRadius: BorderRadius.circular(AppRadii.sm),
+            ),
+          ),
+        ),
+        error: (_, __) => Center(
+          child: Text(
+            isFrench
+                ? 'Impossible de charger les séances.'
+                : 'Could not load sessions.',
+            style: const TextStyle(
+              color: AppColors.textSecondary,
+              fontSize: 13,
+            ),
+          ),
+        ),
       ),
     );
   }
 }
 
-class _SessionData {
-  final String title;
-  final String titleFr;
-  final String duration;
-  final int exercises;
-  final String level;
-  final String levelFr;
-  final Color levelColor;
-  final IconData icon;
-
-  const _SessionData({
-    required this.title,
-    required this.titleFr,
-    required this.duration,
-    required this.exercises,
-    required this.level,
-    required this.levelFr,
-    required this.levelColor,
-    required this.icon,
-  });
-}
-
 class _SessionCard extends StatelessWidget {
-  final _SessionData data;
+  final Session session;
   final bool isFrench;
 
-  const _SessionCard({required this.data, required this.isFrench});
+  const _SessionCard({required this.session, required this.isFrench});
+
+  IconData _iconForSession() {
+    final lower = session.name.toLowerCase();
+    if (lower.contains('upper') || lower.contains('push') || lower.contains('pull')) {
+      return Icons.fitness_center_rounded;
+    }
+    if (lower.contains('leg') || lower.contains('lower')) {
+      return Icons.directions_walk_rounded;
+    }
+    if (lower.contains('hiit') || lower.contains('cardio')) {
+      return Icons.bolt_rounded;
+    }
+    if (lower.contains('core') || lower.contains('abs')) {
+      return Icons.sports_gymnastics_rounded;
+    }
+    return Icons.accessibility_new_rounded;
+  }
 
   @override
   Widget build(BuildContext context) {
+    final palette = AppDifficultyTheme.paletteFor(session.difficulty);
+    final Color levelColor = palette.accentColor;
+    final String levelLabel =
+        AppDifficultyTheme.label(session.difficulty, isFrench: isFrench);
+    final int durationMinutes = session.estimatedDuration ~/ 60;
+    final String durationLabel =
+        durationMinutes > 0 ? '$durationMinutes min' : '—';
+
     return GestureDetector(
       onTap: () {},
       child: Container(
@@ -1697,7 +1634,7 @@ class _SessionCard extends StatelessWidget {
                       borderRadius: BorderRadius.circular(AppRadii.sm),
                     ),
                     child: Icon(
-                      data.icon,
+                      _iconForSession(),
                       color: AppColors.primary,
                       size: 18,
                     ),
@@ -1709,18 +1646,16 @@ class _SessionCard extends StatelessWidget {
                       vertical: 2,
                     ),
                     decoration: BoxDecoration(
-                      color:
-                          data.levelColor.withValues(alpha: AppOpacity.subtle),
+                      color: levelColor.withValues(alpha: AppOpacity.subtle),
                       borderRadius: BorderRadius.circular(AppRadii.sm),
                       border: Border.all(
-                        color:
-                            data.levelColor.withValues(alpha: AppOpacity.mild),
+                        color: levelColor.withValues(alpha: AppOpacity.mild),
                       ),
                     ),
                     child: Text(
-                      isFrench ? data.levelFr : data.level,
+                      levelLabel,
                       style: TextStyle(
-                        color: data.levelColor,
+                        color: levelColor,
                         fontSize: 9,
                         fontWeight: FontWeight.w700,
                       ),
@@ -1730,7 +1665,7 @@ class _SessionCard extends StatelessWidget {
               ),
               const Spacer(),
               Text(
-                isFrench ? data.titleFr : data.title,
+                session.name,
                 maxLines: 1,
                 overflow: TextOverflow.ellipsis,
                 style: const TextStyle(
@@ -1750,7 +1685,7 @@ class _SessionCard extends StatelessWidget {
                   ),
                   const SizedBox(width: 3),
                   Text(
-                    data.duration,
+                    durationLabel,
                     style: const TextStyle(
                       color: AppColors.textSecondary,
                       fontSize: 11,
@@ -1764,9 +1699,7 @@ class _SessionCard extends StatelessWidget {
                   ),
                   const SizedBox(width: 3),
                   Text(
-                    isFrench
-                        ? '${data.exercises} ex.'
-                        : '${data.exercises} ex.',
+                    '${session.workouts.length} ex.',
                     style: const TextStyle(
                       color: AppColors.textSecondary,
                       fontSize: 11,
@@ -1879,31 +1812,3 @@ class _QuickAccessCard extends StatelessWidget {
   }
 }
 
-// ─────────────────────────────────────────────────────────────────────────────
-// Logout button
-// ─────────────────────────────────────────────────────────────────────────────
-
-class _LogoutButton extends StatelessWidget {
-  final bool isFrench;
-  final VoidCallback onLogout;
-
-  const _LogoutButton({required this.isFrench, required this.onLogout});
-
-  @override
-  Widget build(BuildContext context) {
-    return OutlinedButton.icon(
-      onPressed: onLogout,
-      icon: const Icon(Icons.logout_rounded, size: 18),
-      label: Text(isFrench ? 'Se déconnecter' : 'Sign out'),
-      style: OutlinedButton.styleFrom(
-        foregroundColor: AppColors.textSecondary,
-        side: BorderSide(
-            color: AppColors.primaryLight.withValues(alpha: AppOpacity.firm)),
-        minimumSize: const Size(double.infinity, 44),
-        shape: RoundedRectangleBorder(
-          borderRadius: BorderRadius.circular(AppRadii.sm),
-        ),
-      ),
-    );
-  }
-}


### PR DESCRIPTION
## Summary

Visual and UX polish for the home screen: flattened banner, unified session hero card using real data, warmup category selection moved to a bottom sheet, carousels capped to preset data only, and sign-out button removed.

## Changes

**Banner**
- Removed `ClipPath` / `_ArchClipper` arch decoration — banner now has a clean flat bottom edge

**Session Hero Card**
- Merged `_SessionOfTheDayCard` (hardcoded gradient design) + `_CurrentProgramDayCard` (real data, plain design) + `_ProgramCardContainer` into a single `_SessionHeroCard` widget
- Uses the gradient/ring design of the old hardcoded card, but powered by `activeProgramStateProvider` + `programByIdProvider` real data
- Handles loading (spinner) and error states within the gradient card

**Warmup Flow**
- Removed category chip button from the home screen warmup selector
- Start button now opens a `showModalBottomSheet` with `_WarmupCategoryTile` rows
- Confirm button is disabled until a category is selected

**Carousels — Preset Data Only**
- Programs carousel switched from `programsProvider` to new `homePresetProgramsProvider` (preset programs, max 5)
- Sessions carousel converted to `ConsumerWidget` using `presetSessionsProvider` (max 10 items)
- Added `homePresetProgramsProvider` to `workout_providers.dart`

**Sign-out Button**
- `_LogoutButton` class and its call-site removed from home screen

## Files Changed

| File | Action |
|---|---|
| `lib/views/home/home_dashboard_tab.dart` | Modified (~400 lines net) |
| `lib/providers/workout_providers.dart` | Modified (+10 lines) |

## Testing

- All 159 existing unit/widget tests pass — no regressions
- `flutter analyze` reports zero errors on both changed files
- Edge cases verified: no active program → placeholder card; loading → spinner in gradient card; error → message in gradient card

## Related Issues

Closes #67